### PR TITLE
feat: import and adapt proto from etcd/raft

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,9 @@
               <version>${spotbugs.version}</version>
             </dependency>
           </dependencies>
+          <configuration>
+            <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
     </license>
   </licenses>
 
+  <modules>
+    <module>proto</module>
+  </modules>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 Kaijie Chen
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>rakit</artifactId>
+    <groupId>org.kaijie.rakit</groupId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>proto</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Rakit Proto</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+      </extension>
+    </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/proto/src/main/proto/raft.proto
+++ b/proto/src/main/proto/raft.proto
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2015 The etcd Authors
+ * Copyright 2022 Kaijie Chen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+option java_package = "org.kaijie.rakit.proto";
+option java_outer_classname = "Proto";
+package proto;
+
+enum EntryType {
+  ENTRY_NORMAL         = 0;
+	ENTRY_CONF_CHANGE    = 1; // corresponds to ConfChange
+	ENTRY_CONF_CHANGE_V2 = 2; // corresponds to ConfChangeV2
+}
+
+message Entry {
+  EntryType type  = 1;
+  uint64    term  = 2;
+  uint64    index = 3;
+  bytes     data  = 4;
+}
+
+message SnapshotMetadata {
+  ConfState conf_state = 1;
+  uint64    index      = 2;
+  uint64    term       = 3;
+}
+
+message Snapshot {
+  bytes            data     = 1;
+  SnapshotMetadata metadata = 2;
+}
+
+// For description of different message types, see:
+// https://pkg.go.dev/go.etcd.io/raft/v3#hdr-MessageType
+enum MessageType {
+  MSG_HUP             = 0;
+  MSG_BEAT            = 1;
+  MSG_PROPOSE         = 2;
+  MSG_APPEND          = 3;
+  MSG_APPEND_RESP     = 4;
+  MSG_VOTE            = 5;
+  MSG_VOTE_RESP       = 6;
+  MSG_SNAPSHOT        = 7;
+  MSG_HEARTBEAT       = 8;
+  MSG_HEARTBEAT_RESP  = 9;
+  MSG_UNREACHABLE     = 10;
+  MSG_SNAPSHOT_STATUS = 11;
+  MSG_CHECK_QUORUM    = 12;
+  MSG_TRANSFER_LEADER = 13;
+  MSG_TIMEOUT_NOW     = 14;
+  MSG_READ_INDEX      = 15;
+  MSG_READ_INDEX_RESP = 16;
+  MSG_PRE_VOTE        = 17;
+  MSG_PRE_VOTE_RESP   = 18;
+}
+
+message Message {
+  MessageType    type        = 1;
+  uint64         to          = 2;
+  uint64         from        = 3;
+  uint64         term        = 4;
+  // logTerm is generally used for appending Raft logs to followers. For example,
+  // (type=MsgApp,index=100,logTerm=5) means leader appends entries starting at
+  // index=101, and the term of entry at index 100 is 5.
+  // (type=MsgAppResp,reject=true,index=100,logTerm=5) means follower rejects some
+  // entries from its leader as it already has an entry with term 5 at index 100.
+  uint64         log_term    = 5;
+  uint64         index       = 6;
+  repeated Entry entries     = 7;
+  uint64         commit      = 8;
+	// snapshot is non-nil and non-empty for MsgSnap messages and nil for all other
+	// message types. However, peer nodes running older binary versions may send a
+	// non-nil, empty value for the snapshot field of non-MsgSnap messages. Code
+	// should be prepared to handle such messages.
+  Snapshot       snapshot    = 9;
+  bool           reject      = 10;
+  uint64         reject_hint = 11;
+  bytes          context     = 12;
+}
+
+message HardState {
+  uint64 term   = 1;
+  uint64 vote   = 2;
+  uint64 commit = 3;
+}
+
+// ConfChangeTransition specifies the behavior of a configuration change with
+// respect to joint consensus.
+enum ConfChangeTransition {
+  // Automatically use the simple protocol if possible, otherwise fall back
+  // to ConfChangeJointImplicit. Most applications will want to use this.
+  CONF_CHANGE_TRANSITION_AUTO           = 0;
+  // Use joint consensus unconditionally, and transition out of them
+  // automatically (by proposing a zero configuration change).
+  //
+  // This option is suitable for applications that want to minimize the time
+  // spent in the joint configuration and do not store the joint configuration
+  // in the state machine (outside of InitialState).
+  CONF_CHANGE_TRANSITION_JOINT_IMPLICIT = 1;
+  // Use joint consensus and remain in the joint configuration until the
+  // application proposes a no-op configuration change. This is suitable for
+  // applications that want to explicitly control the transitions, for example
+  // to use a custom payload (via the Context field).
+  CONF_CHANGE_TRANSITION_JOINT_EXPLICIT = 2;
+}
+
+message ConfState {
+  // The voters in the incoming config. (If the configuration is not joint,
+  // then the outgoing config is empty).
+  repeated uint64 voters            = 1;
+  // The learners in the incoming config.
+  repeated uint64 learners          = 2;
+  // The voters in the outgoing config.
+  repeated uint64 voters_outgoing   = 3;
+  // The nodes that will become learners when the outgoing config is removed.
+  // These nodes are necessarily currently in nodes_joint (or they would have
+  // been added to the incoming config right away).
+  repeated uint64 learners_next     = 4;
+  // If set, the config is joint and Raft will automatically transition into
+  // the final config (i.e. remove the outgoing config) when this is safe.
+  bool            auto_leave        = 5;
+}
+
+enum ConfChangeType {
+  CONF_CHANGE_ADD_NODE         = 0;
+  CONF_CHANGE_REMOVE_NODE      = 1;
+  CONF_CHANGE_UPDATE_NODE      = 2;
+  CONF_CHANGE_ADD_LEARNER_NODE = 3;
+}
+
+message ConfChange {
+	ConfChangeType  type    = 2;
+	uint64          node_id = 3;
+	bytes           context = 4;
+
+	// NB: this is used only by etcd to thread through a unique identifier.
+	// Ideally it should really use the Context instead. No counterpart to
+	// this field exists in ConfChangeV2.
+	uint64          id      = 1;
+}
+
+// ConfChangeSingle is an individual configuration change operation. Multiple
+// such operations can be carried out atomically via a ConfChangeV2.
+message ConfChangeSingle {
+  ConfChangeType  type    = 1;
+  uint64          node_id = 2;
+}
+
+// ConfChangeV2 messages initiate configuration changes. They support both the
+// simple "one at a time" membership change protocol and full Joint Consensus
+// allowing for arbitrary changes in membership.
+//
+// The supplied context is treated as an opaque payload and can be used to
+// attach an action on the state machine to the application of the config change
+// proposal. Note that contrary to Joint Consensus as outlined in the Raft
+// paper[1], configuration changes become active when they are *applied* to the
+// state machine (not when they are appended to the log).
+//
+// The simple protocol can be used whenever only a single change is made.
+//
+// Non-simple changes require the use of Joint Consensus, for which two
+// configuration changes are run. The first configuration change specifies the
+// desired changes and transitions the Raft group into the joint configuration,
+// in which quorum requires a majority of both the pre-changes and post-changes
+// configuration. Joint Consensus avoids entering fragile intermediate
+// configurations that could compromise survivability. For example, without the
+// use of Joint Consensus and running across three availability zones with a
+// replication factor of three, it is not possible to replace a voter without
+// entering an intermediate configuration that does not survive the outage of
+// one availability zone.
+//
+// The provided ConfChangeTransition specifies how (and whether) Joint Consensus
+// is used, and assigns the task of leaving the joint configuration either to
+// Raft or the application. Leaving the joint configuration is accomplished by
+// proposing a ConfChangeV2 with only and optionally the Context field
+// populated.
+//
+// For details on Raft membership changes, see:
+//
+// [1]: https://github.com/ongardie/dissertation/blob/master/online-trim.pdf
+message ConfChangeV2 {
+  ConfChangeTransition      transition = 1;
+  repeated ConfChangeSingle changes    = 2;
+  bytes                     context    = 3;
+}

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 Kaijie Chen
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<FindBugsFilter>
+  <Match>
+    <Package name="org.kaijie.rakit.proto"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Description

Import proto definition from etcd/raft with following changes:

1. Migrate from proto2 to proto3.
2. Migrate from Go to Java.
3. Follow the naming convention of protobuf.

## Type of change

* [x] feat: (new feature for the user, not a new feature for build script)
* [ ] fix: (bug fix for the user, not a fix to a build script)
* [ ] docs: (changes to the documentation)
* [ ] style: (formatting, missing semi colons, etc; no production code change)
* [ ] refactor: (refactoring production code, eg. renaming a variable)
* [ ] test: (adding missing tests, refactoring tests; no production code change)
* [ ] chore: (updating grunt tasks etc; no production code change)

## How has this been tested?

No need.