### PR TITLE
chore: add configuration for protobuf-maven-plugin

### DIFF
--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -50,6 +50,12 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+          <!-- With multiple executions, this must be `false` otherwise we wipe out the previous execution -->
+          <clearOutputDirectory>false</clearOutputDirectory>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Description

Add configuration for `protobuf-maven-plugin`:

1. Set `protocArtifact` explicitly.
2. Set `outputDirectory` to `generated-sources` (instead of `generated-sources/protobuf`).
3. Set `clearOutputDirectory` to `false` to allow multiple executions.

## Type of change

* [ ] feat: (new feature for the user, not a new feature for build script)
* [ ] fix: (bug fix for the user, not a fix to a build script)
* [ ] docs: (changes to the documentation)
* [ ] style: (formatting, missing semi colons, etc; no production code change)
* [ ] refactor: (refactoring production code, eg. renaming a variable)
* [ ] test: (adding missing tests, refactoring tests; no production code change)
* [x] chore: (updating grunt tasks etc; no production code change)

## How has this been tested?

Manually.